### PR TITLE
Add missing default services

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The following services are included by default:
 * Sendgrid
 * TravisCI
 * Discord
+* Adobe
+* Atlassian
+* Apple
+* Apple Developer
+* Cloudflare
+* Azure
+* Oracle Cloud
 
 Feel free to create a PR to add more services.
 


### PR DESCRIPTION
This PR adds the new services from the last commit (9faf214) to the README.